### PR TITLE
REMOVE specific minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "gulp-coffee": "~2.3.1",
     "gulp-concat": "~2.6.0",
     "gulp-imagemin": "~3.0.1",
-    "gulp-minify": "~0.0.5",
     "gulp-minify-html": "~1.0.4",
     "gulp-plumber": "~1.1.0",
     "gulp-ruby-haml": "~0.0.4",

--- a/src/templates/layout.pug
+++ b/src/templates/layout.pug
@@ -14,4 +14,4 @@ html(lang='fr')
 
 script(src="//code.jquery.com/jquery-1.11.3.min.js")
 script(src='//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js' integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous")
-script(src='/js/all-min.js')
+script(src='/js/all.js')

--- a/tasks/assets.coffee
+++ b/tasks/assets.coffee
@@ -6,7 +6,6 @@ coffee      = require 'gulp-coffee'
 concat      = require 'gulp-concat'
 gutil       = require 'gulp-util'
 imagemin    = require 'gulp-imagemin'
-minify      = require 'gulp-minify'
 nano        = require 'gulp-cssnano'
 plumber     = require 'gulp-plumber'
 pngquant    = require 'imagemin-pngquant'
@@ -31,7 +30,6 @@ gulp.task 'coffee', ->
     .pipe(coffee({bare: true}).on('error', gutil.log))
     .pipe(concat('all.js'))
     .pipe(uglify())
-    .pipe(minify())
     .pipe(gulp.dest(paths.destination.javascripts))
 
 


### PR DESCRIPTION
We have a gulp task to minifiy javascripts. But this is already done by
uglification, as a consequence, `all.js` and `all-min.js` have exactly
the same content. Second minification should be removed.

Details
- REMOVE specific js minification step
